### PR TITLE
fix: refactor vapid keys

### DIFF
--- a/HEADER.md
+++ b/HEADER.md
@@ -13,6 +13,8 @@ This module is provided without any kind of warranty and is AGPL3 licensed.
 
 ## Pricing model
 
+> TODO: Pricing should be still finalized.
+
 At the moment of writing, the architecture is composed of the following components:
 
 ## Using Redis in Memorystore
@@ -37,7 +39,7 @@ For a total of:
 - GKE Autopilot free-tier: **65$/monthly**
 - GKE Autopilot: **135$/monthly**
 
-> NOTE: Elasticsearch integration is not yet finished.
+> TODO: Elasticsearch integration is not yet integrated here.
 
 [1]: https://cloud.google.com/kubernetes-engine/pricing#cluster_management_fee_and_free_tier
 [2]: https://cloud.google.com/sql/pricing

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ For a total of:
 
 ## Using Redis in GKE
 
-1.  Redis master - "0.250 CPU / 512MB" - **8$/monthly**
-2.  Redis replicas 3 x "0.250 CPU / 512MB" on Spot nodes - **7$/Monthly**
+1.  Redis master - "0.250 CPU / 512MB" - **8$**
+2.  Redis replicas 3 x 0.250 CPU / 512MB on Spot nodes - **7$**
 
 For a total of:
 
@@ -72,12 +72,14 @@ For a total of:
 | <a name="input_app_create_admin"></a> [app\_create\_admin](#input\_app\_create\_admin) | Create admin account | `bool` | `false` | no |
 | <a name="input_app_existing_secret_name"></a> [app\_existing\_secret\_name](#input\_app\_existing\_secret\_name) | Mastodon existing secret name | `string` | `null` | no |
 | <a name="input_app_helm_additional_values"></a> [app\_helm\_additional\_values](#input\_app\_helm\_additional\_values) | Additional values to pass to the helm | `string` | `""` | no |
-| <a name="input_app_keys"></a> [app\_keys](#input\_app\_keys) | Mastodon secret keys | `set(string)` | <pre>[<br>  "secret_key_base",<br>  "otp_secret",<br>  "vapid_private_key",<br>  "vapid_public_key"<br>]</pre> | no |
+| <a name="input_app_keys"></a> [app\_keys](#input\_app\_keys) | Mastodon secret keys | `set(string)` | <pre>[<br>  "secret_key_base",<br>  "otp_secret"<br>]</pre> | no |
 | <a name="input_app_locale"></a> [app\_locale](#input\_app\_locale) | Mastodon locale | `string` | `"en"` | no |
 | <a name="input_app_s3_existing_secret"></a> [app\_s3\_existing\_secret](#input\_app\_s3\_existing\_secret) | S3 existing secret name | `string` | `null` | no |
 | <a name="input_app_smtp_existing_secret"></a> [app\_smtp\_existing\_secret](#input\_app\_smtp\_existing\_secret) | SMTP existing secret name | `string` | `null` | no |
 | <a name="input_app_smtp_password"></a> [app\_smtp\_password](#input\_app\_smtp\_password) | SMTP password | `string` | `null` | no |
 | <a name="input_app_smtp_username"></a> [app\_smtp\_username](#input\_app\_smtp\_username) | SMTP username | `string` | `null` | no |
+| <a name="input_app_vapid_private_key"></a> [app\_vapid\_private\_key](#input\_app\_vapid\_private\_key) | Mastodon vapid private key | `string` | `null` | no |
+| <a name="input_app_vapid_public_key"></a> [app\_vapid\_public\_key](#input\_app\_vapid\_public\_key) | Mastodon vapid public key | `string` | `null` | no |
 | <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Force destroy bucket | `bool` | `false` | no |
 | <a name="input_bucket_location"></a> [bucket\_location](#input\_bucket\_location) | Bucket location | `string` | n/a | yes |
 | <a name="input_bucket_storage_class"></a> [bucket\_storage\_class](#input\_bucket\_storage\_class) | The Storage Class of the new bucket. | `string` | `null` | no |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -14,13 +14,17 @@ mastodon:
   smtp:
     existingSecret: ${MASTODON_SMTP_EXISTING_SECRET}
   secrets:
-    existingSecret: ${MASTODON_APP_EXISTING_SECRET_NAME}
+    secret_key_base: ${MASTODON_SECRET_KEY_BASE}
+    otp_secret: ${MASTODON_OTP_SECRET}
+    vapid:
+      private_key: ${MASTODON_VAPID_PRIVATE_KEY}
+      public_key: ${MASTODON_VAPID_PUBLIC_KEY}
   streaming:
     replicas: 2
   web:
     replicas: 2
   worker:
-    replicas: 1
+    replicas: 2
 
 ingress:
   enabled: true

--- a/mastodon.tf
+++ b/mastodon.tf
@@ -10,7 +10,10 @@ locals {
       MASTODON_S3_EXISTING_SECRET : var.app_s3_existing_secret != null ? var.app_s3_existing_secret : kubernetes_secret.s3_secret.metadata[0].name
       MASTODON_S3_BUCKET_NAME : google_storage_bucket.bucket.name
       MASTODON_SMTP_EXISTING_SECRET : var.app_smtp_existing_secret != null ? var.app_smtp_existing_secret : kubernetes_secret.mastodon_smtp_secret[0].metadata[0].name
-      MASTODON_APP_EXISTING_SECRET_NAME : var.app_existing_secret_name != null ? var.app_existing_secret_name : kubernetes_secret.mastodon_secrets.metadata[0].name
+      MASTODON_SECRET_KEY_BASE : local.mastodon_secrets["SECRET_KEY_BASE"]
+      MASTODON_OTP_SECRET : local.mastodon_secrets["OTP_SECRET"]
+      MASTODON_VAPID_PUBLIC_KEY : var.app_vapid_public_key
+      MASTODON_VAPID_PRIVATE_KEY : var.app_vapid_private_key
       MASTODON_POSTGRES_HOST : module.sql_db.private_ip_address
       MASTODON_POSTGRES_USER : "mastodon"
       MASTODON_POSTGRES_DB : "mastodon"

--- a/variables.tf
+++ b/variables.tf
@@ -180,7 +180,7 @@ variable "cloudsql_pgsql_version" {
 variable "app_keys" {
   type        = set(string)
   description = "Mastodon secret keys"
-  default     = (["secret_key_base", "otp_secret", "vapid_private_key", "vapid_public_key"])
+  default     = (["secret_key_base", "otp_secret"])
 }
 
 variable "app_create_admin" {
@@ -235,6 +235,18 @@ variable "app_smtp_existing_secret" {
 variable "app_existing_secret_name" {
   type        = string
   description = "Mastodon existing secret name"
+  default     = null
+}
+
+variable "app_vapid_public_key" {
+  type        = string
+  description = "Mastodon vapid public key"
+  default     = null
+}
+
+variable "app_vapid_private_key" {
+  type        = string
+  description = "Mastodon vapid private key"
   default     = null
 }
 


### PR DESCRIPTION
They must be generated manually with:

```
❯ k exec -it cd-mastodon-16410ce7-web-5c6766865c-nc5lr -- sh
$ RAILS_ENV=production bundle exec rake mastodon:webpush:generate_vapid_key
```